### PR TITLE
Update var name in code snippets to be consistent

### DIFF
--- a/content/tutorials/iris.md
+++ b/content/tutorials/iris.md
@@ -233,9 +233,9 @@ ${\displaystyle \Theta^{(k+1)}=\Theta^{(k)}-\gamma \nabla f\left(\Theta^{(k)}\ri
 To do so, we need to pass $\Theta$ to the `Step` method of the `Solver`:
 
 ```go
-update := []gorgonia.ValueGrad{theta}
+model := []gorgonia.ValueGrad{theta}
 // ...
-if err = solver.Step(update); err != nil {
+if err = solver.Step(model); err != nil {
         log.Fatal(err)
 }
 ```


### PR DESCRIPTION
Make the document easier to follow by updating "update" var to "model" as the context below use "model" to refer []ValueGrad.