### PR TITLE
Add vanity import for Vulkan repository

### DIFF
--- a/content/vanity-import-paths/vulkan.md
+++ b/content/vanity-import-paths/vulkan.md
@@ -1,0 +1,5 @@
++++
+date = 2021-04-07T10:53:00+02:00
+title = "Vulkan"
+vanity = "https://github.com/gorgonia/vulkan"
++++


### PR DESCRIPTION
We'll probably change the name of the repo at some point but it's nice to make it go-gettable already so I can get the badges in the readme working.