### PR TITLE
Bump Hugo Github Action version to fix deprecated path error

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
         submodules: true
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2.2.2
+      uses: peaceiris/actions-hugo@v2.5.0
       with:
         hugo-version: '0.58.3'
         extended: true


### PR DESCRIPTION
Closes #111. I bumped the version of the github action to the newest version. I kept de Hugo version the same. Not tested because I don't have a server configured for that. Let me know if you need anything else.

There is a chance that the action after this one has the same problem. But let's try this first.