### PR TITLE
static/css: remove font-weight override

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -85,7 +85,6 @@ b, strong, label, th {
 }
 #sidebar {
     border: 1px solid #dadce0;
-    font-weight: 200 !important;
 }
 fieldset {
     border: 1px solid #ddd;
@@ -180,7 +179,6 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
     width: 250px;
     bottom: 0;
     left: 0;
-    font-weight: 200;
     font-size: 15px;
 }
 #sidebar a {


### PR DESCRIPTION
The font-weight 200 is too light for the given fonts.

Before:

![2023-03-02 16_22_26-Getting Started __ Gorgonia - before](https://user-images.githubusercontent.com/192964/222456177-3c442951-2346-4ec8-a6fd-b1b29bed2cba.png)

After:

![2023-03-02 16_22_07-Getting Started __ Gorgonia - After](https://user-images.githubusercontent.com/192964/222456224-b604441d-9a48-4039-9e15-0bc67ff039c4.png)