### PR TITLE
Improve no moving gc fix 

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -67,9 +67,11 @@ panic: Something in this program imports go4.org/unsafe/assume-no-moving-gc to d
 
 then do 
 
-`export ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=go1.19 ` 
+`export ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=go1.XX ` 
 
-and then run the program again.
+with `XX` being the minor version defined in your `go.mod`-file.
+
+Then run the program again.
 
 For further explanation, please see the [Hello World tutorial](/tutorials/hello-world).
 


### PR DESCRIPTION
In the getting-started guide the version defined to fix the non-moving garbage collector is hard-coded to 1.19. I think it should be made clear that the version from the projects go.mod is needed here.